### PR TITLE
Update guidance on ARIA `role` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ The HTML code of an email should use as much semantic markup as possible. The us
 <h1 style="margin:0; color:#0f0; font:24px Arial, sans-serif;">Lorem ipsum</h1>
 ```
 
-Container tags such as `<header>`, `<main>`, `<footer>`, `<article>` or `<section>` are to use with caution as several major email clients (like Gmail or Outlook.com) don't support them. These are preferred to be replaced by `role` attributes instead.
+Container tags such as `<header>`, `<main>`, `<footer>`, `<article>` or `<section>` are to be used with caution as several major email clients (like Gmail or Outlook.com) don't support them. It is preferred to use the corresponding [implicit ARIA `role`](https://www.w3.org/TR/html-aria/#implicit) of the given element instead.
+
+```html
+<!-- Bad example -->
+<header>
+  <h1>Lorem ipsum</h1>
+</header>
+
+<!-- Good example -->
+<div role="banner">
+  <h1>Lorem ipsum</h1>
+</div>
+```
 
 ## Tables for layout
 
@@ -138,16 +150,16 @@ This is especially helpful in case an email client has strong default styles. Fo
 ```html
 <!-- Bad-ish example -->
 <table style="border:0; border-spacing:0;">
-	<tr>
-		<td style="padding:0; border:none;">Lorem ipsum.</td>
-	</tr>
+  <tr>
+    <td style="padding:0; border:none;">Lorem ipsum.</td>
+  </tr>
 </table>
 
 <!-- Good-ish example -->
 <table border="0" cellspacing="0" cellpadding="0">
-	<tr>
-		<td>Lorem ipsum.</td>
-	</tr>
+  <tr>
+    <td>Lorem ipsum.</td>
+  </tr>
 </table>
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,16 +150,16 @@ This is especially helpful in case an email client has strong default styles. Fo
 ```html
 <!-- Bad-ish example -->
 <table style="border:0; border-spacing:0;">
-  <tr>
-    <td style="padding:0; border:none;">Lorem ipsum.</td>
-  </tr>
+	<tr>
+		<td style="padding:0; border:none;">Lorem ipsum.</td>
+	</tr>
 </table>
 
 <!-- Good-ish example -->
 <table border="0" cellspacing="0" cellpadding="0">
-  <tr>
-    <td>Lorem ipsum.</td>
-  </tr>
+	<tr>
+		<td>Lorem ipsum.</td>
+	</tr>
 </table>
 ```
 


### PR DESCRIPTION
This PR adds an example of "bad" vs "good" markup, and a link to https://www.w3.org/TR/html-aria/#implicit such that developers can find the corresponding ARIA role if they want to convey the semantics of a certain HTML element.

<hr>

As an aside, I _wanted_ to include this table to provide a shortcut for which `role` is implicit of each (widely used) element. 

| Element      | Implicit ARIA `role`
| ------------ | ------------------- |
| `<header>`   | `banner`            |
| `<main>`     | `main`              |
| `<footer>`   | `contentinfo`       |
| `<article>`  | `article`           |
| `<section>`  | `region`            |
| `<aside>`    | `complementary`     |

But the implicitness may change for certain elements depending on some factors, e.g. the [`<header>` element](https://www.w3.org/TR/html-aria/#el-header):

> If not a descendant of an `article`, `aside`, `main`, `nav` or `section` element, or an element with `role=article`, `complementary`, `main`, `navigation` or `region` then `role=banner`, otherwise No corresponding role

And since I didn't want to get too wordy, I decided not to include it. Developers can use the link instead and find out for themselves what to use.